### PR TITLE
Bump moment-timezone to 0.5.26

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "moment-timezone": {
-      "version": "0.5.23",
-      "from": "moment-timezone@0.5.23",
+      "version": "0.5.26",
+      "from": "moment-timezone@0.5.26",
       "dependencies": {
         "moment": {
           "version": "2.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moment",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A lib to proxy moment as America/Sao_Paulo",
   "main": "index.js",
   "repository": {
@@ -10,6 +10,6 @@
   "author": "Pagar.me Pagamentos S/A <@pagarme>",
   "license": "ISC",
   "dependencies": {
-    "moment-timezone": "0.5.23"
+    "moment-timezone": "0.5.26"
   }
 }


### PR DESCRIPTION
# Description

This PR aims to update the current `moment-timezone` version to the latest version.

This version removes 2019's DST from Brazilian timezones which is the correct timezones definition.