### PR TITLE
feat: update momentjs library

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,8 +5,8 @@
       "from": "moment-timezone@0.5.26",
       "dependencies": {
         "moment": {
-          "version": "2.23.0",
-          "from": "moment@2.23.0"
+          "version": "2.29.4",
+          "from": "moment@2.29.4"
         }
       }
     }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "moment-timezone": {
-      "version": "0.5.26",
-      "from": "moment-timezone@0.5.26",
+      "version": "0.5.43",
+      "from": "moment-timezone@0.5.43",
       "dependencies": {
         "moment": {
           "version": "2.29.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "author": "Pagar.me Pagamentos S/A <@pagarme>",
   "license": "ISC",
   "dependencies": {
-    "moment-timezone": "0.5.26"
+    "moment-timezone": "0.5.43"
   }
 }


### PR DESCRIPTION
Com o bump do node para a versão 16 no pagarme-core se tornou necessário a atualização da biblioteca moment por conta de alguns erros gerados na nova versão do node.